### PR TITLE
Update version of surefire plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
     <version.jacoco-maven-plugin>0.8.3</version.jacoco-maven-plugin>
     <version.maven-checkstyle-plugin>3.0.0</version.maven-checkstyle-plugin>
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
+    <version.maven-surefire-plugin>3.0.0-M3</version.maven-surefire-plugin>
     <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
   </properties>
 
@@ -243,6 +244,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.maven-surefire-plugin}</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
This PR updates the version of the Maven Surefire Plugin (milestone version). This fixes compilation on OpenJDK 8.