### PR TITLE
Add auto-formatting via google style

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
     <!-- plugins -->
     <version.jacoco-maven-plugin>0.8.5</version.jacoco-maven-plugin>
-    <version.maven-checkstyle-plugin>3.1.0</version.maven-checkstyle-plugin>
+    <version.maven-fmt-plugin>2.9</version.maven-fmt-plugin>
     <version.maven-gpg-plugin>1.6</version.maven-gpg-plugin>
     <version.maven-surefire-plugin>3.0.0-M4</version.maven-surefire-plugin>
     <version.nexus-staging-maven-plugin>1.6.8</version.nexus-staging-maven-plugin>
@@ -163,22 +163,13 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${version.maven-checkstyle-plugin}</version>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>${version.maven-fmt-plugin}</version>
         <executions>
           <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <configuration>
-              <configLocation>https://raw.githubusercontent.com/dbmdz/development/master/code-quality/checkstyle.xml</configLocation>
-              <encoding>UTF-8</encoding>
-              <consoleOutput>true</consoleOutput>
-              <failsOnError>true</failsOnError>
-              <linkXRef>false</linkXRef>
-            </configuration>
             <goals>
-              <goal>check</goal>
+              <goal>format</goal>
             </goals>
           </execution>
         </executions>

--- a/src/main/java/de/digitalcollections/iiif/demo/config/SpringConfigBackendDemo.java
+++ b/src/main/java/de/digitalcollections/iiif/demo/config/SpringConfigBackendDemo.java
@@ -7,6 +7,4 @@ import org.springframework.context.annotation.Import;
 
 @Configuration
 @Import({SpringConfigBackendImage.class, SpringConfigBackendPresentation.class})
-public class SpringConfigBackendDemo {
-
-}
+public class SpringConfigBackendDemo {}

--- a/src/main/java/de/digitalcollections/iiif/demo/config/SpringConfigDemo.java
+++ b/src/main/java/de/digitalcollections/iiif/demo/config/SpringConfigDemo.java
@@ -6,12 +6,11 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 
-@ComponentScan(basePackages = {
-  "de.digitalcollections.iiif.hymir.image",
-  "de.digitalcollections.iiif.hymir.presentation"
-})
+@ComponentScan(
+    basePackages = {
+      "de.digitalcollections.iiif.hymir.image",
+      "de.digitalcollections.iiif.hymir.presentation"
+    })
 @Configuration
 @Import({CustomResponseHeaders.class, SpringConfig.class})
-public class SpringConfigDemo {
-
-}
+public class SpringConfigDemo {}

--- a/src/main/java/de/digitalcollections/iiif/demo/config/SpringConfigSecurityDemo.java
+++ b/src/main/java/de/digitalcollections/iiif/demo/config/SpringConfigSecurityDemo.java
@@ -6,6 +6,4 @@ import org.springframework.context.annotation.Import;
 
 @Configuration
 @Import(SpringConfigSecurity.class)
-public class SpringConfigSecurityDemo {
-
-}
+public class SpringConfigSecurityDemo {}

--- a/src/main/java/de/digitalcollections/iiif/demo/config/SpringConfigWebDemo.java
+++ b/src/main/java/de/digitalcollections/iiif/demo/config/SpringConfigWebDemo.java
@@ -16,8 +16,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Import(SpringConfigWeb.class)
 public class SpringConfigWebDemo implements WebMvcConfigurer {
 
-  @Autowired
-  private ServerUrlInterceptor serverUrlInterceptor;
+  @Autowired private ServerUrlInterceptor serverUrlInterceptor;
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {

--- a/src/main/java/de/digitalcollections/iiif/demo/frontend/ViewController.java
+++ b/src/main/java/de/digitalcollections/iiif/demo/frontend/ViewController.java
@@ -9,29 +9,32 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-/**
- * Demo controller for serving IIIF services on demo data.
- */
+/** Demo controller for serving IIIF services on demo data. */
 @Controller
 public class ViewController {
 
-  @Autowired
-  private UrlHelper urlHelper;
+  @Autowired private UrlHelper urlHelper;
 
-  @RequestMapping(value = {"", "/"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"", "/"},
+      method = RequestMethod.GET)
   public String getHomepage(Model model) {
     model.addAttribute("active", "home");
     return "index";
   }
 
-  @RequestMapping(value = {"/about"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"/about"},
+      method = RequestMethod.GET)
   public String getAbout(Model model) {
     model.addAttribute("active", "about");
     return "about";
   }
 
   /* Image API */
-  @RequestMapping(value = {"/image-request-url.html"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"/image-request-url.html"},
+      method = RequestMethod.GET)
   public String getImageRequestUrlDemo(Model model, HttpServletRequest request) {
     model.addAttribute("active", "demos");
     String baseUrl = urlHelper.getBaseUrl(request);
@@ -39,7 +42,9 @@ public class ViewController {
     return "image-api/view_image-request-url";
   }
 
-  @RequestMapping(value = {"/image-info-url.html"}, method = RequestMethod.GET)
+  @RequestMapping(
+      value = {"/image-info-url.html"},
+      method = RequestMethod.GET)
   public String getImageInfoUrlDemo(Model model, HttpServletRequest request) {
     model.addAttribute("active", "demos");
     String baseUrl = urlHelper.getBaseUrl(request);
@@ -62,8 +67,11 @@ public class ViewController {
   }
 
   /* Presentation API */
-  @RequestMapping(value = {"/{identifier}/presentation-manifest-url.html"}, method = RequestMethod.GET)
-  public String getPresentationManifestUrlDemo(@PathVariable String identifier, Model model, HttpServletRequest request) {
+  @RequestMapping(
+      value = {"/{identifier}/presentation-manifest-url.html"},
+      method = RequestMethod.GET)
+  public String getPresentationManifestUrlDemo(
+      @PathVariable String identifier, Model model, HttpServletRequest request) {
     model.addAttribute("active", "demos");
     String baseUrl = urlHelper.getBaseUrl(request);
     model.addAttribute("baseUrl", baseUrl);
@@ -71,8 +79,11 @@ public class ViewController {
     return "presentation-api/view_presentation-manifest-url";
   }
 
-  @RequestMapping(value = {"/{name}/presentation-collection-url.html"}, method = RequestMethod.GET)
-  public String getPresentationCollectionUrlDemo(@PathVariable String name, Model model, HttpServletRequest request) {
+  @RequestMapping(
+      value = {"/{name}/presentation-collection-url.html"},
+      method = RequestMethod.GET)
+  public String getPresentationCollectionUrlDemo(
+      @PathVariable String name, Model model, HttpServletRequest request) {
     model.addAttribute("active", "demos");
     String baseUrl = urlHelper.getBaseUrl(request);
     model.addAttribute("baseUrl", baseUrl);
@@ -101,7 +112,9 @@ public class ViewController {
     return "tify/view";
   }
 
-  @RequestMapping(value = "/{identifier}/view_leaflet-presentation.html", method = RequestMethod.GET)
+  @RequestMapping(
+      value = "/{identifier}/view_leaflet-presentation.html",
+      method = RequestMethod.GET)
   public String getLeafletManifestViewerPage(@PathVariable String identifier, Model model) {
     model.addAttribute("active", "demos");
     model.addAttribute("manifestId", "/presentation/v2/" + identifier + "/manifest");
@@ -123,42 +136,54 @@ public class ViewController {
     return "mirador/view_canvaslink";
   }
 
-  @RequestMapping(value = "/{identifier}/view_mirador_downloadmenu.html", method = RequestMethod.GET)
+  @RequestMapping(
+      value = "/{identifier}/view_mirador_downloadmenu.html",
+      method = RequestMethod.GET)
   public String getMiradorDownloadMenuPage(@PathVariable String identifier, Model model) {
     model.addAttribute("active", "demos");
     model.addAttribute("manifestId", "/presentation/v2/" + identifier + "/manifest");
     return "mirador/view_downloadmenu";
   }
 
-  @RequestMapping(value = "/{identifier}/view_mirador_imagecropper.html", method = RequestMethod.GET)
+  @RequestMapping(
+      value = "/{identifier}/view_mirador_imagecropper.html",
+      method = RequestMethod.GET)
   public String getMiradorImageCropperPage(@PathVariable String identifier, Model model) {
     model.addAttribute("active", "demos");
     model.addAttribute("manifestId", "/presentation/v2/" + identifier + "/manifest");
     return "mirador/view_imagecropper";
   }
 
-  @RequestMapping(value = "/{identifier}/view_mirador_keyboardnavigation.html", method = RequestMethod.GET)
+  @RequestMapping(
+      value = "/{identifier}/view_mirador_keyboardnavigation.html",
+      method = RequestMethod.GET)
   public String getMiradorKeyboardNavigationPage(@PathVariable String identifier, Model model) {
     model.addAttribute("active", "demos");
     model.addAttribute("manifestId", "/presentation/v2/" + identifier + "/manifest");
     return "mirador/view_keyboardnavigation";
   }
 
-  @RequestMapping(value = "/{identifier}/view_mirador_manifestbutton.html", method = RequestMethod.GET)
+  @RequestMapping(
+      value = "/{identifier}/view_mirador_manifestbutton.html",
+      method = RequestMethod.GET)
   public String getMiradorManifestButtonPage(@PathVariable String identifier, Model model) {
     model.addAttribute("active", "demos");
     model.addAttribute("manifestId", "/presentation/v2/" + identifier + "/manifest");
     return "mirador/view_manifestbutton";
   }
 
-  @RequestMapping(value = "/{identifier}/view_mirador_multipagenavigation.html", method = RequestMethod.GET)
+  @RequestMapping(
+      value = "/{identifier}/view_mirador_multipagenavigation.html",
+      method = RequestMethod.GET)
   public String getMiradorMultiPageNavigationPage(@PathVariable String identifier, Model model) {
     model.addAttribute("active", "demos");
     model.addAttribute("manifestId", "/presentation/v2/" + identifier + "/manifest");
     return "mirador/view_multipagenavigation";
   }
 
-  @RequestMapping(value = "/{identifier}/view_mirador_physicalruler.html", method = RequestMethod.GET)
+  @RequestMapping(
+      value = "/{identifier}/view_mirador_physicalruler.html",
+      method = RequestMethod.GET)
   public String getMiradorPhysicalRulerPage(@PathVariable String identifier, Model model) {
     model.addAttribute("active", "demos");
     model.addAttribute("manifestId", "/presentation/v2/" + identifier + "/manifest");

--- a/src/main/java/de/digitalcollections/iiif/demo/interceptor/ServerUrlInterceptor.java
+++ b/src/main/java/de/digitalcollections/iiif/demo/interceptor/ServerUrlInterceptor.java
@@ -11,15 +11,14 @@ import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
 @Component
 public class ServerUrlInterceptor extends HandlerInterceptorAdapter {
 
-  @Autowired
-  private DemoPresentationServiceImpl demoPresentationServiceImpl;
+  @Autowired private DemoPresentationServiceImpl demoPresentationServiceImpl;
 
-  @Autowired
-  private UrlHelper urlHelper;
+  @Autowired private UrlHelper urlHelper;
 
   // before the actual handler will be executed
   @Override
-  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+      throws Exception {
     String requestUrl = request.getRequestURL().toString();
     if (requestUrl.endsWith("/manifest") || requestUrl.matches(".*?/canvas/.*?/view$")) {
       String serverUrl = urlHelper.getBaseUrl(request);

--- a/src/main/java/de/digitalcollections/iiif/demo/repository/DemoPresentationRepositoryImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/demo/repository/DemoPresentationRepositoryImpl.java
@@ -9,20 +9,20 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 
-/**
- * IIIF Presentation repository for all manifests.
- */
+/** IIIF Presentation repository for all manifests. */
 @Primary
 @Repository
 public class DemoPresentationRepositoryImpl extends PresentationRepositoryImpl {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DemoPresentationRepositoryImpl.class);
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DemoPresentationRepositoryImpl.class);
 
   private final String serverUrlPlaceholder = "http://localhost:8080";
   private String serverUrl;
 
   @Override
-  public String getResourceJson(URI manifestUri) throws ResolvingException, ResourceNotFoundException {
+  public String getResourceJson(URI manifestUri)
+      throws ResolvingException, ResourceNotFoundException {
     String json = super.getResourceJson(manifestUri);
     json = replaceUrlEndpoints(json);
     LOGGER.debug("manifest json: " + json);
@@ -39,8 +39,8 @@ public class DemoPresentationRepositoryImpl extends PresentationRepositoryImpl {
       resultingJson = resultingJson.replaceAll(this.serverUrlPlaceholder, this.serverUrl);
       LOGGER.info(
           "replaced all occurrences of the placeholder {} with the application url {}",
-          this.serverUrlPlaceholder, this.serverUrl
-      );
+          this.serverUrlPlaceholder,
+          this.serverUrl);
     }
     return resultingJson;
   }

--- a/src/main/java/de/digitalcollections/iiif/demo/service/DemoPresentationServiceImpl.java
+++ b/src/main/java/de/digitalcollections/iiif/demo/service/DemoPresentationServiceImpl.java
@@ -12,15 +12,15 @@ import org.springframework.stereotype.Service;
 @Service
 public class DemoPresentationServiceImpl extends PresentationServiceImpl {
 
-  @Autowired
-  private DemoPresentationRepositoryImpl demoPresentationRepository;
+  @Autowired private DemoPresentationRepositoryImpl demoPresentationRepository;
 
-  public DemoPresentationServiceImpl(PresentationRepository presentationRepository, @Autowired(required = false) PresentationSecurityService presentationSecurityService) {
+  public DemoPresentationServiceImpl(
+      PresentationRepository presentationRepository,
+      @Autowired(required = false) PresentationSecurityService presentationSecurityService) {
     super(presentationRepository, presentationSecurityService);
   }
 
   public void setServerUrl(String serverUrl) {
     demoPresentationRepository.setServerUrl(serverUrl);
   }
-
 }

--- a/src/main/java/de/digitalcollections/iiif/demo/util/UrlHelper.java
+++ b/src/main/java/de/digitalcollections/iiif/demo/util/UrlHelper.java
@@ -3,9 +3,7 @@ package de.digitalcollections.iiif.demo.util;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Component;
 
-/**
- * Helper class that aids in retrieving the base url
- */
+/** Helper class that aids in retrieving the base url */
 @Component
 public class UrlHelper {
 

--- a/src/test/java/de/digitalcollections/iiif/demo/frontend/ViewControllerTest.java
+++ b/src/test/java/de/digitalcollections/iiif/demo/frontend/ViewControllerTest.java
@@ -1,5 +1,10 @@
 package de.digitalcollections.iiif.demo.frontend;
 
+import static org.hamcrest.CoreMatchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,17 +17,11 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.model;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class ViewControllerTest {
 
-  @Autowired
-  private WebApplicationContext webApplicationContext;
+  @Autowired private WebApplicationContext webApplicationContext;
 
   private MockMvc mockMvc;
 
@@ -47,21 +46,24 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetImageRequestUrlDemo() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/image-request-url.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/image-request-url.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
   }
 
   @Test
   public void shouldGetImageInfoUrlDemo() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/image-info-url.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/image-info-url.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
   }
 
   @Test
   public void shouldGetOpenSeadragonPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_image.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/view_image.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("infoUrl", is("/image/v2/12345/info.json")));
@@ -69,7 +71,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetLeafletImageViewerPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_leaflet-image.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/view_leaflet-image.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("infoUrl", is("/image/v2/12345/info.json")));
@@ -77,7 +80,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetPresentationManifestDemo() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/presentation-manifest-url.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/presentation-manifest-url.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));
@@ -85,7 +89,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetCollectionManifestDemo() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/presentation-collection-url.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/presentation-collection-url.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/collection/12345")));
@@ -93,7 +98,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetMiradorPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_mirador.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/view_mirador.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));
@@ -101,7 +107,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetTifyPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_tify.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/view_tify.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));
@@ -109,7 +116,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetUniversalViewerPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_universal.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/view_universal.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));
@@ -117,7 +125,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetLeafletManifestViewerPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_leaflet-presentation.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/view_leaflet-presentation.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));
@@ -125,7 +134,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetMiradorCanvasLinkPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_mirador_canvaslink.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/view_mirador_canvaslink.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));
@@ -133,7 +143,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetMiradorImageCropperPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_mirador_imagecropper.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/view_mirador_imagecropper.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));
@@ -141,7 +152,9 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetMiradorKeyboardNavigationPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_mirador_keyboardnavigation.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(
+            get("/12345/view_mirador_keyboardnavigation.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));
@@ -149,7 +162,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetMiradorManifestButtonPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_mirador_manifestbutton.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/view_mirador_manifestbutton.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));
@@ -157,7 +171,9 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetMiradorMultiPageNavigationPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_mirador_multipagenavigation.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(
+            get("/12345/view_mirador_multipagenavigation.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));
@@ -165,7 +181,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetMiradorPyhsicalRulerPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_mirador_physicalruler.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/view_mirador_physicalruler.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));
@@ -173,7 +190,8 @@ public class ViewControllerTest {
 
   @Test
   public void shouldGetMiradorViewFromUrlPage() throws Exception {
-    ResultActions perform = mockMvc.perform(get("/12345/view_mirador_viewfromurl.html").accept(MediaType.TEXT_HTML));
+    ResultActions perform =
+        mockMvc.perform(get("/12345/view_mirador_viewfromurl.html").accept(MediaType.TEXT_HTML));
     perform.andExpect(status().isOk());
     perform.andExpect(model().attribute("active", is("demos")));
     perform.andExpect(model().attribute("manifestId", is("/presentation/v2/12345/manifest")));

--- a/src/test/java/de/digitalcollections/iiif/demo/repository/DemoPresentationRepositoryImplTest.java
+++ b/src/test/java/de/digitalcollections/iiif/demo/repository/DemoPresentationRepositoryImplTest.java
@@ -1,9 +1,9 @@
 package de.digitalcollections.iiif.demo.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class DemoPresentationRepositoryImplTest {
 
@@ -27,7 +27,8 @@ public class DemoPresentationRepositoryImplTest {
   public void testReplaceUrlEndpointsWithContext() throws Exception {
     repository.setServerUrl("http://localhost:8080/demo");
     String result = repository.replaceUrlEndpoints(jsonStringtoModify);
-    String expectedResult = "{\"@id\":\"http://localhost:8080/demo/presentation/v2/bsb00026283/manifest\"}";
+    String expectedResult =
+        "{\"@id\":\"http://localhost:8080/demo/presentation/v2/bsb00026283/manifest\"}";
     assertThat(result).isEqualTo(expectedResult);
   }
 
@@ -35,7 +36,8 @@ public class DemoPresentationRepositoryImplTest {
   public void testReplaceUrlEndpointsWithOtherHost() throws Exception {
     repository.setServerUrl("http://virtualbox:8080/demo");
     String result = repository.replaceUrlEndpoints(jsonStringtoModify);
-    String expectedResult = "{\"@id\":\"http://virtualbox:8080/demo/presentation/v2/bsb00026283/manifest\"}";
+    String expectedResult =
+        "{\"@id\":\"http://virtualbox:8080/demo/presentation/v2/bsb00026283/manifest\"}";
     assertThat(result).isEqualTo(expectedResult);
   }
 }


### PR DESCRIPTION
This MR replaces checkstyle with a maven-plugin that automatically reformats the code to conform with the Google Java Style Guide during the format execution goal, which is executed during the standard clean install and clean test targets.